### PR TITLE
メッセージ追加不具合の修正

### DIFF
--- a/src/chatwork.coffee
+++ b/src/chatwork.coffee
@@ -204,6 +204,7 @@ class ChatworkStreaming extends EventEmitter
     headers =
       "Host"           : @host
       "X-ChatWorkToken": @token
+      "Content-Type"   : 'application/x-www-form-urlencoded'
 
     options =
       "agent"  : false


### PR DESCRIPTION
メッセージ追加API `/rooms/{room_id}/messages` 利用時に、下記のようなエラーログとともに失敗する不具合があります。その修正をしました。

```
[Fri Nov 28 2014 13:00:56 GMT+0900 (JST)] ERROR Chatwork HTTPS status code: 400
[Fri Nov 28 2014 13:00:56 GMT+0900 (JST)] ERROR Chatwork HTTPS response data: {"errors":["Parameter 'body' is required"]}
```
