### PR TITLE
change bot output message format

### DIFF
--- a/src/chatwork.coffee
+++ b/src/chatwork.coffee
@@ -130,6 +130,7 @@ class ChatworkStreaming extends EventEmitter
         @get "#{baseUrl}/messages", "", callback
 
       create: (text, callback) =>
+        text = '[info]' + text + '[/info]'
         body = "body=#{text}"
         @post "#{baseUrl}/messages", body, callback
 


### PR DESCRIPTION
chatworkのbotからの発言を[info][/info]で囲むようにしていただきたいです。
※他にベターな方法があればいいのですが
