### PR TITLE
Fixed a bug that stops `Room(roomId).Messages().listen()` If an error occurs in the http request

### DIFF
--- a/src/chatwork.coffee
+++ b/src/chatwork.coffee
@@ -236,11 +236,13 @@ class ChatworkStreaming extends EventEmitter
 
       response.on "error", (err) ->
         logger.error "Chatwork HTTPS response error: #{err}"
-        callback err, {}
+        if callback
+          callback err, {}
 
     request.end body, 'binary'
 
     request.on "error", (err) ->
       logger.error "Chatwork request error: #{err}"
-      callback err, {}
+      if callback
+        callback err, {}
 

--- a/src/chatwork.coffee
+++ b/src/chatwork.coffee
@@ -242,4 +242,5 @@ class ChatworkStreaming extends EventEmitter
 
     request.on "error", (err) ->
       logger.error "Chatwork request error: #{err}"
+      callback err, {}
 


### PR DESCRIPTION
It does not call a callback when an error has occurred in the http request.
Therefore, `Room(roomId).Messages().listen()` will not loop.

For example, the following error.

```
[Sun Jun 26 2016 23:56:53 GMT+0000 (UTC)] ERROR Chatwork request error: Error: getaddrinfo ENOTFOUND api.chatwork.com
```
